### PR TITLE
update heim dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ dirs = "3.0.1"
 structopt = "0.3"
 anyhow = "1.0"
 futures = "0.3"
-heim = { version = "0.0.11", default-features = false, features = [ "host" ] }
+heim = { version = "0.1.0-rc.1", default-features = false, features = [ "host" ] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"


### PR DESCRIPTION
`platforms` dependency of `heim` changed. Old version is no longer available. 